### PR TITLE
feat: make hourly data persistent across restarts

### DIFF
--- a/custom_components/smart_irrigation/const.py
+++ b/custom_components/smart_irrigation/const.py
@@ -14,6 +14,11 @@ ICON = "mdi:sprinkler"
 SENSOR = "sensor"
 PLATFORMS = [SENSOR]
 
+# Data file
+DATA_FILE_PREFIX = DOMAIN + "_"
+DATA_FILE_SUFFIX = ".json"
+DATA_PROPERTY_NAMES = ("hourly_precipitation", "hourly_evapotranspiration")
+
 # Configuration and options
 CONF_API_KEY = "api_key"
 CONF_REFERENCE_ET = "reference_evapotranspiration"

--- a/custom_components/smart_irrigation/sensor.py
+++ b/custom_components/smart_irrigation/sensor.py
@@ -527,14 +527,14 @@ class SmartIrrigationSensor(SmartIrrigationEntity):
                 self.bucket_delta, self.type
             )
             self.water_budget = result["wb"]
-            self.coordinator.hourly_precipitation_list.append(self.precipitation)
-            self.coordinator.hourly_evapotranspiration_list.append(
-                self.evapotranspiration
-            )
+            precip_list = self.coordinator.update_data_property("hourly_precipitation",
+                                                                self.precipitation)
+            evapo_list = self.coordinator.update_data_property("hourly_evapotranspiration",
+                                                               self.evapotranspiration)
             _LOGGER.info(
                 "update_state: just updated hourly_precipitation_list: {} and hourly_evapotranspiration_list: {}".format(  # pylint: disable=logging-format-interpolation
-                    self.coordinator.hourly_precipitation_list,
-                    self.coordinator.hourly_evapotranspiration_list,
+                    precip_list,
+                    evapo_list
                 )
             )
             return result["art"]


### PR DESCRIPTION
During the hourly update, the precipitation and evapotranspiration lists
are saved in a file named `smart_irrigation_<name>.json` in the /config
directory.

Upon startup, the saved data is loaded into the coordinator instance,
but only if auto refresh is enabled (since when auto refresh is enabled,
it's possible to tell if the saved data is stale).

While loading the saved data, if the data is determined to be stale, (ie,
between when the data was last saved and the time that HA is starting
there should've been an auto refresh) the data is discarded.