### PR TITLE
Use OpenMapWeather One Call API 3.0

### DIFF
--- a/custom_components/smart_irrigation/OWMClient.py
+++ b/custom_components/smart_irrigation/OWMClient.py
@@ -8,8 +8,8 @@ import math
 _LOGGER = logging.getLogger(__name__)
 
 # Open Weather Map URL
-# OWM_URL = "https://api.openweathermap.org/data/2.5/onecall?units=metric&lat={}&lon={}&appid={}"
-OWM_URL = "https://api.openweathermap.org/data/3.0/onecall?lat={}&lon={}&appid={}"
+OWM_URL = "https://api.openweathermap.org/data/3.0/onecall?lat={}&lon={}&appid={}&units={}"
+UNITS = "metric"
 
 # Required OWM keys for validation
 OWM_temp_key_name = "temp"
@@ -40,7 +40,7 @@ class OWMClient:  # pylint: disable=invalid-name
         self.api_key = api_key.strip()
         self.longitude = longitude
         self.latitude = latitude
-        self.url = OWM_URL.format(latitude, longitude, api_key)
+        self.url = OWM_URL.format(latitude, longitude, api_key, UNITS)
 
     def get_data(self):
         """Validate and return data."""

--- a/custom_components/smart_irrigation/OWMClient.py
+++ b/custom_components/smart_irrigation/OWMClient.py
@@ -8,7 +8,8 @@ import math
 _LOGGER = logging.getLogger(__name__)
 
 # Open Weather Map URL
-OWM_URL = "https://api.openweathermap.org/data/2.5/onecall?units=metric&lat={}&lon={}&appid={}"
+# OWM_URL = "https://api.openweathermap.org/data/2.5/onecall?units=metric&lat={}&lon={}&appid={}"
+OWM_URL = "https://api.openweathermap.org/data/3.0/onecall?lat={}&lon={}&appid={}"
 
 # Required OWM keys for validation
 OWM_temp_key_name = "temp"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Smart Irrigation OWM API v3.0",
+    "name": "Smart Irrigation",
     "render_readme": true,
     "domains": ["sensor"]
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Smart Irrigation",
+    "name": "Smart Irrigation OWM API v3.0",
     "render_readme": true,
     "domains": ["sensor"]
   }


### PR DESCRIPTION
New API keys seem to have no access to OpenMapWeather API 2.5.
This PR was tested on an API key that was generated on Dec 17, 2022.