### PR TITLE
Add automated basic test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.x"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.test.txt
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/smart_irrigation/manifest.json
+++ b/custom_components/smart_irrigation/manifest.json
@@ -1,14 +1,18 @@
 {
   "domain": "smart_irrigation",
   "name": "Smart Irrigation",
+  "codeowners": [
+    "@jeroenterheerdt"
+  ],
   "config_flow": true,
+  "dependencies": [],
   "documentation": "https://github.com/jeroenterheerdt/HASmartIrrigation",
+  "homekit": {},
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jeroenterheerdt/HASmartIrrigation/issues",
   "requirements": [],
   "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
-  "codeowners": ["@jeroenterheerdt"],
-  "version": "0.0.78"
+  "version": "0.0.78",
+  "zeroconf": []
 }

--- a/custom_components/smart_irrigation/requirements.txt
+++ b/custom_components/smart_irrigation/requirements.txt
@@ -1,2 +1,1 @@
-pyeto
 git+https://github.com/woodcrafty/PyETo.git

--- a/custom_components/smart_irrigation/sensor.py
+++ b/custom_components/smart_irrigation/sensor.py
@@ -363,6 +363,7 @@ class SmartIrrigationSensor(SmartIrrigationEntity):
             data = {}
             # if we have an api we're reading at least part of the data from OWM, so read the data
             if self.coordinator.api:
+                print(self.coordinator)
                 data = self.coordinator.data["daily"][0]
                 
             # retrieve the data from the sensors (if set) and build the data or overwrite what we got from the API

--- a/custom_components/smart_irrigation/strings.json
+++ b/custom_components/smart_irrigation/strings.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Please check your reference evapotranspiration values - they should be decimal and at least one should be non-zero.",
       "sensornotfound": "One or more of the sensors specified do not exist"
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Step 1/7: Name and evapotranspiration calculation",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "Maximum duration should be >=-1.",
       "initial_update_delay_error": "Initial update delay should be >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/en.json
+++ b/custom_components/smart_irrigation/translations/en.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Please check your reference evapotranspiration values - they should be decimal and at least one should be non-zero.",
       "sensornotfound": "One or more of the sensors specified do not exist"
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Step 1/7: Name and evapotranspiration calculation",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "Maximum duration should be >=-1.",
       "initial_update_delay_error": "Initial update delay should be >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/fr.json
+++ b/custom_components/smart_irrigation/translations/fr.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Vérifiez vos valeurs de référence d'évapotranspiration - Elles doivent être décimales et au moins une différente de zéro.",
       "sensornotfound": "Un ou plusieurs capteurs n'existe pas"
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Étape 1/7: Nom et calcul de l'évapotranspiration",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "La durée maximale doit être >=-1.",
       "initial_update_delay_error": "Le délai de première mise à jour doit être >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/it.json
+++ b/custom_components/smart_irrigation/translations/it.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Si prega di controllare i valori di riferimento dell'evapotraspirazione: dovrebbero essere decimali e almeno uno dovrebbe essere diverso da zero.",
       "sensornotfound": "Uno o piu' sensori specificati non esistono "
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Step 1/7: Nome e calcolo dell'evapotraspirazione",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "La durata massima dovrebbe essere >=-1.",
       "initial_update_delay_error": "Il ritardo di aggiornamento iniziale dovrebbe essere >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/nb.json
+++ b/custom_components/smart_irrigation/translations/nb.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Sjekk referanseverdiene for fordampningstranspirasjon - de skal være desimal og minst én skal være null.",
       "sensornotfound": "En eller flere av sensorene som er spesifisert, eksisterer ikke"
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Trinn 1/7: Beregning av navn og fordampning",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "Maksimal varighet skal være >=-1.",
       "initial_update_delay_error": "Innledende oppdateringsforsinkelse bør være >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/pt.json
+++ b/custom_components/smart_irrigation/translations/pt.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Por favor verifique os valores de referência de evotranspiração - estes devem ser decimais e pelo menos um diferente de zero.",
       "sensornotfound": "Um ou mais dos sensores especificados não existem."
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Passo 1/7: Nome e calculo de evotranspiração",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "Duração maxima deve ser >=-1.",
       "initial_update_delay_error": "Atraso inicial de atualização deve ser >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/custom_components/smart_irrigation/translations/sp.json
+++ b/custom_components/smart_irrigation/translations/sp.json
@@ -9,7 +9,6 @@
       "reference_evapotranspiration_problem": "Por favor verifique los valores de referencia de evaporación - Deberían ser en decimales y al menos uno distinto de cero.",
       "sensornotfound": "Uno o más de los sensores especificados no existen"
     },
-    "title": "Smart Irrigation",
     "step": {
       "user": {
         "title": "Smart Irrigation - Paso 1/7: Nombre y evapotranspiración cálculo",
@@ -118,6 +117,5 @@
       "maximum_duration_error": "La duración máxima debe ser >=-1.",
       "initial_update_delay_error": "El retraso de la actualización inicial debe ser >=0."
     }
-  },
-  "title": "Smart Irrigation"
+  }
 }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,4 @@
+-r custom_components/smart_irrigation/requirements.txt
+pytest
+pytest-cov
+pytest-homeassistant-custom-component

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Smart Irrigation integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Fixtures for testing."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,11 @@
+"""Test the Smart Irrigation config flow."""
+import pytest
+from custom_components.smart_irrigation import config_flow
+from custom_components.smart_irrigation.const import (
+    DOMAIN,
+)
+from unittest import mock
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME, CONF_PATH
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry, AsyncMock, patch
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,54 @@
+"""Test the Smart Irrigation sensor."""
+import pytest
+from custom_components.smart_irrigation import config_flow
+from custom_components.smart_irrigation.sensor import SmartIrrigationSensor
+from custom_components.smart_irrigation.const import (
+    DOMAIN,
+    CONF_API_KEY,
+    CONF_AREA,
+    CONF_FLOW,
+    CONF_NUMBER_OF_SPRINKLERS,
+    CONF_REFERENCE_ET,
+    CONF_SENSORS,
+    CONF_INITIAL_UPDATE_DELAY,
+    CONF_AUTO_REFRESH
+)
+from unittest import mock
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_NAME, CONF_PATH
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry, AsyncMock, patch, State, mock_restore_cache
+
+
+async def test_add_sensor(hass):
+    """Tests adding a basic sensor."""
+    zone_name = "test_zone"
+    mock_sensor_data = {
+        CONF_AREA: 100,
+        CONF_FLOW: 10,
+        CONF_NUMBER_OF_SPRINKLERS: 1,
+        CONF_REFERENCE_ET: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ],
+        CONF_SENSORS: [],
+    }
+    mock_sensor_options = {
+        CONF_INITIAL_UPDATE_DELAY: 0,
+        CONF_AUTO_REFRESH: False
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, 
+        data=mock_sensor_data, 
+        title=zone_name, 
+        options=mock_sensor_options)
+
+    fake_state = State(f"{DOMAIN}.{entry.entry_id}", {
+        "daily": [0, 0,]
+    })
+    mock_restore_cache(hass, (fake_state,))
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"sensor.{zone_name}_base_schedule_index")
+
+    assert state
+    assert state.state == '0.0'


### PR DESCRIPTION
I'd propose to start adding tests to catch bugs like #130 before they hit larger groups of users. I've added 2 very basic tests:

Hassfest:
Runs on every push / pull requests and daily to keep up with HA updates
Validates the HA plugin

CI:
Runs on every push / pull requests and weekly to keep up with the latest python version (to be prepared for future HA updates), used python versions are 3.10, 3.11 and latest 3.x
The current test is very basic and only checks if the sensor entity can be loaded correctly. Checks for OWM, calculations, etc should be added in the future .
