### PR TITLE
Fix warning about integration using self.async_update_ha_state()

### DIFF
--- a/custom_components/smart_irrigation/sensor.py
+++ b/custom_components/smart_irrigation/sensor.py
@@ -314,7 +314,7 @@ class SmartIrrigationSensor(SmartIrrigationEntity):
             "_hourly_data_updated, calling update_state for type {}".format(self.type)
         )
         self._state = self.update_state()
-        self.hass.add_job(self.async_update_ha_state)
+        self.hass.add_job(self.async_write_ha_state)
 
     @property
     def name(self):


### PR DESCRIPTION
This fixes the warning at boot about integration using async_update_ha_state without forcing the update.