### PR TITLE
Add set_duration service. Refactor service function implementation.

### DIFF
--- a/custom_components/smart_irrigation/const.py
+++ b/custom_components/smart_irrigation/const.py
@@ -95,13 +95,22 @@ ATTR_SET_BUCKET = "set_bucket"
 ATTR_NEW_BUCKET_VALUE = "new_bucket_value"
 ATTR_SET_MULTIPLIER = "set_multiplier"
 ATTR_NEW_MULTIPLIER_VALUE = "new_multiplier_value"
+ATTR_NEW_THROUGHPUT_VALUE = "new_throughput_value"
 ATTR_UPDATE = "update"
 ATTR_UPDATE_ALL = "update_all"
 ATTR_OVERRIDE_CACHE = "override_cache"
 ATTR_RESET_ALL_BUCKETS = "reset_all_buckets"
 ATTR_CLEAR_ALL_WEATHERDATA = "clear_all_weatherdata"
-ATTR_SET_STATE = "set_state"
 ATTR_NEW_STATE_VALUE = "new_state_value"
+ATTR_NEW_DURATION_VALUE = "new_duration_value"
+
+LIST_SET_ZONE_ALLOWED_ARGS = [
+    ATTR_NEW_BUCKET_VALUE,
+    ATTR_NEW_MULTIPLIER_VALUE,
+    ATTR_NEW_DURATION_VALUE,
+    ATTR_NEW_STATE_VALUE,
+    ATTR_NEW_THROUGHPUT_VALUE
+]
 
 ZONE_ID = "id"
 ZONE_NAME = "name"
@@ -119,6 +128,7 @@ ZONE_OLD_BUCKET = "old_bucket"
 ZONE_DELTA = "delta"
 ZONE_EXPLANATION = "explanation"
 ZONE_MULTIPLIER = "multiplier"
+ZONE_THROUGHPUT = "throughput"
 ZONE_MAPPING = "mapping"
 ZONE_LEAD_TIME = "lead_time"
 ZONE_MAXIMUM_DURATION = "maximum_duration"
@@ -261,6 +271,7 @@ SERVICE_SET_BUCKET = "set_bucket"
 SERVICE_SET_ALL_BUCKETS = "set_all_buckets"
 SERVICE_SET_MULTIPLIER = "set_multiplier"
 SERVICE_SET_ALL_MULTIPLIERS = "set_all_multipliers"
-SERVICE_SET_STATE = "set_state"
+SERVICE_SET_ZONE = "set_zone"
 SERVICE_ENTITY_ID = "entity_id"
 SERVICE_CLEAR_WEATHERDATA = "clear_all_weather_data"
+

--- a/custom_components/smart_irrigation/services.yaml
+++ b/custom_components/smart_irrigation/services.yaml
@@ -44,12 +44,28 @@ set_multiplier:
       required: true
       example: 1.0
       default: 1.0
-set_state:
+set_zone:
   target:
     entity:
       domain: sensor
   fields:
+    new_bucket_value:
+      required: false
+      example: -10
+      default: 0
+    new_multiplier_value:
+      required: false
+      example: 1.0
+      default: 1.0
+    new_duration_value:
+      required: false
+      example: 10
+      default: 0
     new_state_value:
-      required: true
+      required: false
       example: "automatic"
       default: "automatic"
+    new_throughput_value:
+      required: false
+      example: 50
+      default: 50

--- a/custom_components/smart_irrigation/translations/en.json
+++ b/custom_components/smart_irrigation/translations/en.json
@@ -158,6 +158,50 @@
           "description": "New value of the state"
         }
       }
+    },
+    "set_duration": {
+      "name": "Set the duration of a zone",
+      "description": "Set the duration of a zone to a specific value, when zone is in manual mode.",
+      "fields": {
+        "entity": {
+          "name": "Entity",
+          "description": "Zone to set state for"
+        },
+        "new_duration_value": {
+          "name": "New duration value",
+          "description": "New value of the duration"
+        }
+      }
+    },
+    "set_zone": {
+      "name": "Set the values of a zone",
+      "description": "Set all configurable values of a zone",
+      "fields": {
+        "entity": {
+          "name": "Entity",
+          "description": "Zone to set configuration values"
+        },
+        "new_bucket_value": {
+          "name": "New bucket value",
+          "description": "New value for the bucket"
+        },
+        "new_multiplier_value": {
+          "name": "New multiplier value",
+          "description": "New value for the multiplier"
+        },
+        "new_duration_value": {
+          "name": "New duration value",
+          "description": "New value for the duration"
+        },
+        "new_state_value": {
+          "name": "New state value",
+          "description": "New value of the state"
+        },
+        "new_throughput_value": {
+          "name": "New throughput value",
+          "description": "New value for the throughput"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The added set_duration allows to specify the irrigation duration if the zone state is set to manual mode.
The refactoring reduces code size by merging how set_duration and set_state are implemented.
New way can likely be applied to all service handler functions if agreed as preferable.

It is even possible to improve code by making those functions be rather data driven for the general case where the input argument for the service is an integer value.

Looking forward to your review.