### PR TITLE
Fix 2025.5.0beta version error

### DIFF
--- a/custom_components/smart_irrigation/const.py
+++ b/custom_components/smart_irrigation/const.py
@@ -1,6 +1,6 @@
 """Store constants."""
 
-VERSION = "v2025.5.0beta"
+VERSION = "v2025.5.0beta0"
 NAME = "Smart Irrigation"
 MANUFACTURER = "@jeroenterheerdt"
 

--- a/custom_components/smart_irrigation/frontend/dist/smart-irrigation.js
+++ b/custom_components/smart_irrigation/frontend/dist/smart-irrigation.js
@@ -1104,7 +1104,7 @@ i.version="2.30.1",n(Za),i.fn=us,i.min=Ja,i.max=Qa,i.now=ei,i.utc=m,i.unix=ds,i.
             .narrow=${this.narrow}
           ></ha-menu-button>
           <div class="main-title">${Zi("title",this.hass.language)}</div>
-          <div class="version">${"v2025.5.0beta"}</div>
+          <div class="version">${"v2025.5.0beta0"}</div>
         </div>
 
         <sl-tab-group

--- a/custom_components/smart_irrigation/frontend/src/const.ts
+++ b/custom_components/smart_irrigation/frontend/src/const.ts
@@ -1,4 +1,4 @@
-export const VERSION = "v2025.5.0beta";
+export const VERSION = "v2025.5.0beta0";
 export const REPO = "https://github.com/jeroenterheerdt/HASmartIrrigation;";
 export const ISSUES_URL = REPO + "/issues";
 

--- a/custom_components/smart_irrigation/manifest.json
+++ b/custom_components/smart_irrigation/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/jeroenterheerdt/HASmartIrrigation/issues",
   "requirements": [],
-  "version": "v2025.5.0beta"
+  "version": "v2025.5.0beta0"
 }


### PR DESCRIPTION
This adds a 0 to the end for v2025.5.0beta0 so the version is valid and loaded by HA

```
2025-05-10 18:22:49.167 ERROR (SyncWorker_6) [homeassistant.loader] The custom integration 'smart_irrigation' does not have a valid version key (v2025.5.0beta) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details
```