### PR TITLE
sensor: Fix unit conversion

### DIFF
--- a/custom_components/smart_irrigation/sensor.py
+++ b/custom_components/smart_irrigation/sensor.py
@@ -202,11 +202,6 @@ class SmartIrrigationZoneEntity(SensorEntity, RestoreEntity):
         return False
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        return self._duration
-
-    @property
     def device_class(self):
         """Return the device class of the sensor."""
         return SensorDeviceClass.DURATION


### PR DESCRIPTION
Don't override state() from sensor.state() because that handles things like automatic unit conversion (for people that prefer to show minutes instead of seconds on dashboards).

The sensor.state() method calls native_value which returns the same value as state (self._duration). Therefore things should simply work when state is just removed.

See: https://github.com/home-assistant/core/blob/761a0877e6135172320b8cc5401fd34f5d782615/homeassistant/components/sensor/__init__.py#L542

Disclaimer: I'm relatively new to the codebase, hopefully I have not overlooked anything.

How to test:

If you change the unit from 's' to 'min' you notice that only the unit changes, but the value is not converted. With this patch applied it does correctly get converted.

![grafik](https://github.com/user-attachments/assets/fcde646a-25c4-4b34-b98d-5b3943cc6c47)
