### PR TITLE
total precipitation within calculation time should not be scaled by hour_multiplier

### DIFF
--- a/custom_components/smart_irrigation/__init__.py
+++ b/custom_components/smart_irrigation/__init__.py
@@ -1448,6 +1448,8 @@ class SmartIrrigationCoordinator(DataUpdateCoordinator):
         data[const.ZONE_OLD_BUCKET] = bucket
         explanation = ""
 
+        hour_multiplier = weatherdata.get(const.MAPPING_DATA_MULTIPLIER, 1.0)
+
         if modinst:
             # if m[const.MODULE_NAME] == "PyETO":
             # if we have precip info from a sensor we don't need to call OWM to get it.
@@ -1459,7 +1461,9 @@ class SmartIrrigationCoordinator(DataUpdateCoordinator):
                 # pyeto expects pressure in hpa, solar radiation in mj/m2/day and wind speed in m/s
 
                 delta = modinst.calculate(
-                    weather_data=weatherdata, forecast_data=forecastdata
+                    weather_data=weatherdata,
+                    forecast_data=forecastdata,
+                    hour_multiplier=hour_multiplier
                 )
             elif m[const.MODULE_NAME] == "Static":
                 delta = modinst.calculate()
@@ -1478,11 +1482,9 @@ class SmartIrrigationCoordinator(DataUpdateCoordinator):
             # data[const.ZONE_BUCKET] = round(bucket+delta,1)
             # data[const.ZONE_DELTA] = round(delta,1)
             _LOGGER.debug("[calculate-module]: retrieved from module: %s", delta)
-            hour_multiplier = weatherdata.get(const.MAPPING_DATA_MULTIPLIER, 1.0)
-            _LOGGER.debug("[calculate-module]: hour_multiplier: %s", hour_multiplier)
-            data[const.ZONE_DELTA] = delta * hour_multiplier
-            _LOGGER.debug("[calculate-module]: new delta: %s", delta * hour_multiplier)
-            newbucket = bucket + (delta * hour_multiplier)
+            data[const.ZONE_DELTA] = delta
+            _LOGGER.debug("[calculate-module]: new delta: %s", delta)
+            newbucket = bucket + delta
 
             # if maximum bucket configured, limit bucket with that.
             # any water above maximum is removed with runoff / bypass flow.

--- a/custom_components/smart_irrigation/calcmodules/pyeto/__init__.py
+++ b/custom_components/smart_irrigation/calcmodules/pyeto/__init__.py
@@ -113,7 +113,7 @@ class PyETO(SmartIrrigationCalculationModule):
         Args:
             weather_data: Dictionary containing current weather data.
             forecast_data: List of dictionaries containing forecasted weather data for upcoming days.
-            hour_multiplier: multiplier of the current time range related to the day period
+            hour_multiplier: fraction of a full 24-hour day that the current calculation period covers.
 
         Returns:
             The mean evapotranspiration delta as a float.
@@ -142,7 +142,8 @@ class PyETO(SmartIrrigationCalculationModule):
         """Calculate the evapotranspiration delta for a single day's weather data.
 
         Args:
-            weather_data: Dictionary containing weather data for the day.
+            weather_data: Dictionary containing weather data for the day..
+            hour_multiplier: fraction of a full 24-hour day that the current calculation period covers.
 
         Returns:
             The evapotranspiration delta as a float.


### PR DESCRIPTION
if the rain sensor detects a precipitation between two calculations, it must be fully considered, as it must be cleared after the calculation as stated in documentation:

_"If you calculate once per day, close to midnight use a source that provides the total precipitation for the day. Often this is called 'daily precipitation'. If you calculate less or more often adjust accordingly. Keep in mind that the total precipitation is expected to be a total over the time period, not the current precipitation."_

This PR should fix https://github.com/jeroenterheerdt/HAsmartirrigation/issues/582