### PR TITLE
Update rain sensor requirement to optional

### DIFF
--- a/blueprints/weather_responsive_scheduling.yaml
+++ b/blueprints/weather_responsive_scheduling.yaml
@@ -22,10 +22,10 @@ blueprint:
     rain_sensor:
       name: Rain Sensor (Optional)
       description: Rain sensor to skip irrigation when raining
-      required: false
       selector:
         entity:
           domain: binary_sensor
+      default: ""
     temperature_threshold:
       name: Temperature Threshold
       description: Skip irrigation if temperature is below this value


### PR DESCRIPTION
Invalid blueprint: extra keys not allowed @ data['blueprint']['input']['rain_sensor']['required']. Got False