### PR TITLE
Fix manual coordinates (config save 400 + values never applied)

### DIFF
--- a/custom_components/smart_irrigation/__init__.py
+++ b/custom_components/smart_irrigation/__init__.py
@@ -446,16 +446,18 @@ class SmartIrrigationCoordinator(DataUpdateCoordinator):
             tuple: (latitude, longitude, elevation)
 
         """
-        # Check if manual coordinates are enabled
-        manual_enabled = self._get_config_value(
-            const.CONF_MANUAL_COORDINATES_ENABLED, False
+        # Manual coordinates are saved via the config API into the store config
+        # (not entry.data / HA config), so read them from there.
+        cfg = self.store.config
+        manual_enabled = getattr(
+            cfg, const.CONF_MANUAL_COORDINATES_ENABLED, False
         )
 
         if manual_enabled:
             # Use manual coordinates
-            latitude = self._get_config_value(const.CONF_MANUAL_LATITUDE, None)
-            longitude = self._get_config_value(const.CONF_MANUAL_LONGITUDE, None)
-            elevation = self._get_config_value(const.CONF_MANUAL_ELEVATION, 0)
+            latitude = getattr(cfg, const.CONF_MANUAL_LATITUDE, None)
+            longitude = getattr(cfg, const.CONF_MANUAL_LONGITUDE, None)
+            elevation = getattr(cfg, const.CONF_MANUAL_ELEVATION, 0)
 
             if latitude is not None and longitude is not None:
                 _LOGGER.info(

--- a/custom_components/smart_irrigation/store.py
+++ b/custom_components/smart_irrigation/store.py
@@ -214,6 +214,13 @@ class Config:
     )
     seasonal_adjustments = attr.ib(type=list, default=CONF_DEFAULT_SEASONAL_ADJUSTMENTS)
     recurring_schedules = attr.ib(type=list, default=CONF_DEFAULT_RECURRING_SCHEDULES)
+    # Manual coordinates (used for weather data instead of HA's location).
+    # Without these fields attr.evolve() would reject the keys the frontend
+    # saves, so the config update would error.
+    manual_coordinates_enabled = attr.ib(type=bool, default=False)
+    manual_latitude = attr.ib(type=float, default=None)
+    manual_longitude = attr.ib(type=float, default=None)
+    manual_elevation = attr.ib(type=float, default=0)
 
 
 class MigratableStore(Store):

--- a/custom_components/smart_irrigation/websockets.py
+++ b/custom_components/smart_irrigation/websockets.py
@@ -97,6 +97,16 @@ class SmartIrrigationConfigView(HomeAssistantView):
                 vol.Optional(const.CONF_SKIP_IRRIGATION_ON_PRECIPITATION): cv.boolean,
                 vol.Optional(const.CONF_PRECIPITATION_THRESHOLD_MM): vol.Coerce(float),
                 vol.Optional(const.CONF_DAYS_BETWEEN_IRRIGATION): vol.Coerce(int),
+                vol.Optional(const.CONF_MANUAL_COORDINATES_ENABLED): cv.boolean,
+                vol.Optional(const.CONF_MANUAL_LATITUDE): vol.Any(
+                    None, vol.Coerce(float)
+                ),
+                vol.Optional(const.CONF_MANUAL_LONGITUDE): vol.Any(
+                    None, vol.Coerce(float)
+                ),
+                vol.Optional(const.CONF_MANUAL_ELEVATION): vol.Any(
+                    None, vol.Coerce(float)
+                ),
             }
         )
     )


### PR DESCRIPTION
Fixes #721.

Enabling **Use manual coordinates** returned `400: extra keys not allowed @ data['manual_coordinates_enabled']`, and the feature was broken at three layers (see the issue for details).

**Changes**
- `websockets.py`: allow `manual_coordinates_enabled` / `manual_latitude` / `manual_longitude` / `manual_elevation` in the config request schema.
- `store.py`: add the four fields to the `Config` attrs class (with defaults) so `attr.evolve()` accepts them and they persist.
- `__init__.py`: in `_get_effective_coordinates`, read the manual coordinates from the store config (where they are saved) instead of `_get_config_value`.

**Testing**

Verified end-to-end on Home Assistant OS:
- `POST /api/smart_irrigation/config` with the manual keys now returns **200** (was 400).
- The values persist in the store.
- After a config-entry reload, the weather client fetches for the manual location (e.g. the PirateWeather request URL switches to the configured lat/lon).

New coordinates take effect on the next weather-client (re)build (config-entry reload / restart), consistent with how the weather-service client is initialised.
