### PR TITLE
fix(weather): Handle null API keys for keyless services

### DIFF
--- a/custom_components/smart_irrigation/__init__.py
+++ b/custom_components/smart_irrigation/__init__.py
@@ -67,6 +67,12 @@ from .websockets import async_register_websockets
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _normalize_api_key(value):
+    """Trim a configured API key while preserving keyless services."""
+    return value.strip() if isinstance(value, str) else None
+
+
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(const.DOMAIN)
 
 
@@ -171,7 +177,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 )
             if const.CONF_WEATHER_SERVICE_API_KEY in entry.data:
                 hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] = (
-                    entry.data.get(const.CONF_WEATHER_SERVICE_API_KEY).strip()
+                    _normalize_api_key(
+                        entry.data.get(const.CONF_WEATHER_SERVICE_API_KEY)
+                    )
                 )
             hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_VERSION] = (
                 entry.data.get(const.CONF_WEATHER_SERVICE_API_VERSION)
@@ -196,12 +204,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             )
         if const.CONF_WEATHER_SERVICE_API_KEY in entry.options:
             hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] = (
-                entry.options.get(const.CONF_WEATHER_SERVICE_API_KEY)
+                _normalize_api_key(
+                    entry.options.get(const.CONF_WEATHER_SERVICE_API_KEY)
+                )
             )
-            if hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] is not None:
-                hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] = hass.data[
-                    const.DOMAIN
-                ][const.CONF_WEATHER_SERVICE_API_KEY].strip()
         if const.CONF_WEATHER_SERVICE_API_VERSION in entry.options:
             hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_VERSION] = (
                 entry.options.get(const.CONF_WEATHER_SERVICE_API_VERSION)
@@ -352,7 +358,9 @@ async def options_update_listener(hass: HomeAssistant, config_entry):
                 )
             if const.CONF_WEATHER_SERVICE_API_KEY in config_entry.options:
                 hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] = (
-                    config_entry.options.get(const.CONF_WEATHER_SERVICE_API_KEY).strip()
+                    _normalize_api_key(
+                        config_entry.options.get(const.CONF_WEATHER_SERVICE_API_KEY)
+                    )
                 )
             hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_VERSION] = (
                 config_entry.options.get(const.CONF_WEATHER_SERVICE_API_VERSION)

--- a/tests/test_keyless_weather_setup.py
+++ b/tests/test_keyless_weather_setup.py
@@ -1,0 +1,111 @@
+"""Regression tests for weather services that do not require an API key."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.smart_irrigation import (
+    _normalize_api_key,
+    async_setup_entry,
+    const,
+    options_update_listener,
+)
+
+
+def test_normalize_api_key_accepts_none_and_trims_strings() -> None:
+    """Keyless services keep None while keyed services still trim whitespace."""
+    assert _normalize_api_key(None) is None
+    assert _normalize_api_key("  secret  ") == "secret"
+    assert _normalize_api_key("") == ""
+
+
+async def test_setup_entry_accepts_keyless_open_meteo(
+    hass: HomeAssistant,
+) -> None:
+    """A persisted Open-Meteo entry with a null key must survive a restart."""
+    entry = Mock()
+    entry.entry_id = "keyless_open_meteo"
+    entry.unique_id = "keyless_open_meteo"
+    entry.data = {
+        const.CONF_INSTANCE_NAME: "Test Smart Irrigation",
+        const.CONF_USE_WEATHER_SERVICE: True,
+        const.CONF_WEATHER_SERVICE: const.CONF_WEATHER_SERVICE_OM,
+        const.CONF_WEATHER_SERVICE_API_KEY: None,
+    }
+    entry.options = {}
+    entry.add_update_listener.return_value = Mock()
+
+    coordinator = Mock()
+    coordinator.id = "keyless_open_meteo"
+    coordinator.use_weather_service = True
+    coordinator.recurring_schedule_manager.async_load_schedules = AsyncMock()
+    coordinator.seasonal_adjustment_manager.async_load_adjustments = AsyncMock()
+    coordinator.irrigation_unlimited_integration.async_initialize = AsyncMock()
+    coordinator.update_subscriptions = AsyncMock()
+    coordinator.async_setup_observed_watering = AsyncMock()
+    coordinator.async_resume_valve_runs = AsyncMock()
+
+    with (
+        patch("custom_components.smart_irrigation.async_get_registry") as registry,
+        patch(
+            "custom_components.smart_irrigation.SmartIrrigationCoordinator",
+            return_value=coordinator,
+        ),
+        patch("custom_components.smart_irrigation.dr.async_get"),
+        patch(
+            "custom_components.smart_irrigation._migrate_duration_unique_ids",
+            new_callable=AsyncMock,
+        ),
+        patch("custom_components.smart_irrigation.async_register_panel"),
+        patch("custom_components.smart_irrigation.async_register_websockets"),
+        patch("custom_components.smart_irrigation.register_services"),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        store = AsyncMock()
+        store.async_get_config.return_value = {
+            const.CONF_USE_WEATHER_SERVICE: True,
+            const.CONF_WEATHER_SERVICE: const.CONF_WEATHER_SERVICE_OM,
+        }
+        store.async_get_zones.return_value = []
+        store.config = Mock(
+            manual_coordinates_enabled=False,
+            manual_latitude=None,
+            manual_longitude=None,
+            manual_elevation=0,
+        )
+        store.get_config = Mock(
+            return_value={
+                const.CONF_AUTO_UPDATE_ENABLED: False,
+                const.CONF_AUTO_CALC_ENABLED: False,
+                const.CONF_AUTO_CLEAR_ENABLED: False,
+                const.START_EVENT_FIRED_TODAY: False,
+            }
+        )
+        registry.return_value = store
+
+        assert await async_setup_entry(hass, entry) is True
+
+    assert hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] is None
+
+
+async def test_options_listener_accepts_null_api_key(mock_hass) -> None:
+    """Reconfiguring a keyless service must not call strip on None."""
+    entry = Mock()
+    entry.entry_id = "keyless_open_meteo"
+    entry.options = {
+        const.CONF_USE_WEATHER_SERVICE: True,
+        const.CONF_WEATHER_SERVICE: const.CONF_WEATHER_SERVICE_OM,
+        const.CONF_WEATHER_SERVICE_API_KEY: None,
+    }
+    mock_hass.data[const.DOMAIN] = {}
+    mock_hass.config_entries = Mock()
+    mock_hass.config_entries.async_reload = AsyncMock()
+
+    await options_update_listener(mock_hass, entry)
+
+    assert mock_hass.data[const.DOMAIN][const.CONF_WEATHER_SERVICE_API_KEY] is None
+    mock_hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)


### PR DESCRIPTION
## Summary

- accept `None` for keyless weather providers such as Open-Meteo
- use the same normalization path for entry data, options, and option reloads
- keep whitespace trimming for providers that use a string API key
- add regression coverage for initial setup and option updates

## Reproduction

An Open-Meteo config entry can persist `weather_service_api_key: null`. On the
next Home Assistant restart, setup currently calls `.strip()` on that value and
raises:

```text
AttributeError: 'NoneType' object has no attribute 'strip'
```

The fix was also validated against a real Home Assistant 2026.7.4 instance: the
entry failed before the patch and loaded successfully after it without adding a
synthetic API key.

## Validation

- `pytest tests/ -q --ignore-glob='**/test_*.py.disabled'` — 187 passed
- `ruff check custom_components/smart_irrigation/`
- `black --check custom_components/smart_irrigation/ tests/test_keyless_weather_setup.py`
